### PR TITLE
Add `oZFile_fwrite` method

### DIFF
--- a/inst/include/XVector_interface.h
+++ b/inst/include/XVector_interface.h
@@ -49,6 +49,13 @@ void filexp_putc(
 	int c
 );
 
+size_t filexp_fwrite(
+	SEXP filexp,
+	const void *data_ptr,
+	size_t size,
+	size_t nitems
+);
+
 int delete_trailing_LF_or_CRLF(
 	const char *buf,
 	int buf_len

--- a/inst/include/_XVector_stubs.c
+++ b/inst/include/_XVector_stubs.c
@@ -66,6 +66,11 @@ DEFINE_NOVALUE_CCALLABLE_STUB(filexp_putc,
 	(     filexp,     c)
 )
 
+DEFINE_CCALLABLE_STUB(size_t, filexp_fwrite,
+	(SEXP filexp, const void *data_ptr, size_t size, size_t nitems),
+	(     filexp,             data_ptr,        size,        nitems)
+)
+
 DEFINE_CCALLABLE_STUB(int, delete_trailing_LF_or_CRLF,
 	(const char *buf, int buf_len),
 	(            buf,     buf_len)

--- a/src/R_init_XVector.c
+++ b/src/R_init_XVector.c
@@ -112,6 +112,7 @@ void R_init_XVector(DllInfo *info)
 	REGISTER_CCALLABLE(_filexp_rewind);
 	REGISTER_CCALLABLE(_filexp_puts);
 	REGISTER_CCALLABLE(_filexp_putc);
+	REGISTER_CCALLABLE(_filexp_fwrite);
 	REGISTER_CCALLABLE(_delete_trailing_LF_or_CRLF);
 
 /* Ocopy_byteblocks.c */

--- a/src/XVector.h
+++ b/src/XVector.h
@@ -45,6 +45,13 @@ void _filexp_putc(
 	int c
 );
 
+size_t _filexp_fwrite(
+	SEXP filexp,
+	const void *data_ptr,
+	size_t size,
+	size_t nitems
+);
+
 SEXP new_input_filexp(SEXP filepath);
 
 SEXP rewind_filexp(SEXP filexp);

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -366,6 +366,29 @@ static int oZFile_puts(const ZFile *zfile, const char *s)
 	error("write error");
 }
 
+static void oZFile_putc(const ZFile *zfile, int c)
+{
+	int ztype;
+	void *file;
+
+	ztype = zfile->ztype;
+	file = zfile->file;
+	switch (ztype) {
+	    case UNCOMPRESSED:
+		if (fputc(c, (FILE *) file) != EOF)
+			return;
+		break;
+	    case GZ_TYPE:
+		if (gzputc((gzFile) file, c) != -1)
+			return;
+		break;
+	    default:
+		error(INTERNAL_ERR_IN "oZFile_putc(): "
+		      "invalid ztype value %d", ztype);
+	}
+	error("write error");
+}
+
 static size_t oZFile_fwrite(const ZFile *zfile, const void *data_ptr,
 			size_t size, size_t nitems)
 {
@@ -389,29 +412,6 @@ static size_t oZFile_fwrite(const ZFile *zfile, const void *data_ptr,
 	if(n == nitems) return nitems;
 	error("write error (attempted to write %zu elements, wrote %zu)",
 		nitems, n);
-}
-
-static void oZFile_putc(const ZFile *zfile, int c)
-{
-	int ztype;
-	void *file;
-
-	ztype = zfile->ztype;
-	file = zfile->file;
-	switch (ztype) {
-	    case UNCOMPRESSED:
-		if (fputc(c, (FILE *) file) != EOF)
-			return;
-		break;
-	    case GZ_TYPE:
-		if (gzputc((gzFile) file, c) != -1)
-			return;
-		break;
-	    default:
-		error(INTERNAL_ERR_IN "oZFile_putc(): "
-		      "invalid ztype value %d", ztype);
-	}
-	error("write error");
 }
 
 /****************************************************************************

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -366,6 +366,31 @@ static int oZFile_puts(const ZFile *zfile, const char *s)
 	error("write error");
 }
 
+static size_t oZFile_fwrite(const ZFile *zfile, const void *data_ptr,
+			size_t size, size_t nitems)
+{
+	int ztype;
+	size_t n = 0;
+	void *file;
+
+	ztype = zfile->ztype;
+	file = zfile->file;
+	switch (ztype) {
+	    case UNCOMPRESSED:
+		n = fwrite(data_ptr, size, nitems, (FILE *) file);
+		break;
+	    case GZ_TYPE:
+		n = gzfwrite(data_ptr, size, nitems, (gzFile) file);
+		break;
+	    default:
+		error(INTERNAL_ERR_IN "oZFile_puts(): "
+		      "invalid ztype value %d", ztype);
+	}
+	if(n == nitems) return nitems;
+	error("write error (attempted to write %zu elements, wrote %zu)",
+		nitems, n);
+}
+
 static void oZFile_putc(const ZFile *zfile, int c)
 {
 	int ztype;

--- a/src/io_utils.c
+++ b/src/io_utils.c
@@ -565,6 +565,11 @@ void _filexp_putc(SEXP filexp, int c)
 	return;
 }
 
+size_t _filexp_fwrite(SEXP filexp, const void *data_ptr, size_t size, size_t nitems){
+	CHECK_USER_INTERRUPT(2000);
+	return oZFile_fwrite(R_ExternalPtrAddr(filexp), data_ptr, size, nitems);
+}
+
 static SEXP new_filexp(SEXP filepath,
 		const char *mode, const char *compress, int level)
 {


### PR DESCRIPTION
Adds analogous `fwrite` method for `oZFile` accessors. `fwrite` tends to be slightly faster than `puts` since it doesn't have to check every character for `'\0'`, which allows for some OS optimization. Would be useful to use in `Biostrings` for `writeXStringSet` since the write size of blocks are known in advance, so appending `'\0'` and then asking the OS to check for it is overkill.

Function arguments follow conventions of the other `oZFile*` functions despite differing from `fwrite` argument syntax.

`gzfwrite` is defined here:

https://github.com/madler/zlib/blob/ef24c4c7502169f016dcd2a26923dbaf3216748c/gzwrite.c#L260-L262

Header definition is here:

https://github.com/madler/zlib/blob/ef24c4c7502169f016dcd2a26923dbaf3216748c/zlib.h#L1472-L1473

I moved the `n==nitems` check to the end of the switch case because I find it significantly more readable than the alternative in `oZFile_puts`.