### PR TITLE
Link to system zlib

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,2 @@
+PKG_LIBS=-lz
+


### PR DESCRIPTION
If you remove the `bioczlib` dependency but you still use `zlib` in your C code, your need to link to the system zlib. This fixes the build on Windows and possibly other platforms: https://github.com/r-universe/bioc/actions/runs/12442707880/job/35018326631
