### PR TITLE
feat: Allow comparison of XVector objects (part 2 of 2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Provides memory efficient S4 classes for storing sequences
 biocViews: Infrastructure, DataRepresentation
 URL: https://bioconductor.org/packages/XVector
 BugReports: https://github.com/Bioconductor/XVector/issues
-Version: 0.47.1
+Version: 0.47.2
 License: Artistic-2.0
 Encoding: UTF-8
 Author: Hervé Pagès and Patrick Aboyoun

--- a/R/SharedVector-class.R
+++ b/R/SharedVector-class.R
@@ -291,9 +291,8 @@ setMethod("order", "SharedVector",
             SharedVector.order(x, decreasing)
         } else {
             args <- unname(args)
-            do.call(order, c(args, list(na.last=na.last,
-                                        decreasing=decreasing,
-                                        method=method)))
+            lapply(args, order,
+                na.last=na.last, decreasing=decreasing, method=method)
         }
     }
 )
@@ -394,5 +393,9 @@ setMethod("==", signature(e1="SharedVector", e2="SharedVector"),
 
 setMethod("!=", signature(e1="SharedVector", e2="SharedVector"),
     function(e1, e2) address(e1@xp) != address(e2@xp)
+)
+
+setMethod("<=", signature(e1="SharedVector", e2="SharedVector"),
+    function(e1, e2) address(e1@xp) <= address(e2@xp)
 )
 

--- a/R/SharedVector-class.R
+++ b/R/SharedVector-class.R
@@ -277,6 +277,27 @@ SharedVector.compare <- function(x1, start1, x2, start2, width)
     .Call2("SharedVector_memcmp",
           x1, start1, x2, start2, width, PACKAGE="XVector")
 
+SharedVector.order <- function(x, decreasing=FALSE){
+    ## will have to add in method arg later
+    ## adding 1L because this method returns 0-indexed values
+    .Call("SharedVector_order",
+        x, length(x), decreasing, PACKAGE="XVector") + 1L
+}
+setMethod("order", "SharedVector",
+    function(..., na.last=TRUE, decreasing=FALSE, method=c("auto", "shell", "radix")){
+        args <- list(...)
+        if (length(args) == 1L) {
+            x <- args[[1L]]
+            SharedVector.order(x, decreasing)
+        } else {
+            args <- unname(args)
+            do.call(order, c(args, list(na.last=na.last,
+                                        decreasing=decreasing,
+                                        method=method)))
+        }
+    }
+)
+
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Low-level copy.

--- a/R/XVector-class.R
+++ b/R/XVector-class.R
@@ -172,20 +172,6 @@ setMethod("bindROWS", "XVector", .concatenate_XVector_objects)
 ### order() and sameAsPreviousROW are required to make XVector compatible with
 ### the equality functions defined in S4Vectors
 
-.XVector.equal <- function(x, y)
-{
-    if (class(x) != class(y) || x@length != y@length)
-        return(FALSE)
-    ans <- !SharedVector.compare(x@shared, x@offset + 1L,
-                                 y@shared, y@offset + 1L,
-                                 x@length)
-    as.logical(ans)
-}
-
-setMethod("==", signature(e1="XVector", e2="XVector"),
-    function(e1, e2) .XVector.equal(e1, e2)
-)
-
 .XVector.order <- function(x, decreasing=FALSE){
     SharedVector.order(x@shared, decreasing)
 }
@@ -213,3 +199,31 @@ setMethod("order", "XVector",
     }
 }
 setMethod("sameAsPreviousROW", "XVector", .XVector.sameAsPreviousROW)
+
+## These methods are defined so that the XVector argument comes first
+## this matters because of how S4Vectors::pcompare is defined; it attempts
+## to coerce the second argument to a list and then concatenate, which can
+## cause weird behavior if the first element is an atomic vector and the
+## second is an XVector object.
+setMethod("==", signature(e1="ANY", e2="XVector"),
+    function(e1, e2) { pcompare(e2, e1) == 0 }
+)
+
+setMethod("<=", signature(e1="ANY", e2="XVector"),
+    function(e1, e2) { pcompare(e2, e1) >= 0L }
+)
+
+.XVector.equal <- function(x, y)
+{
+    if (class(x) != class(y) || x@length != y@length)
+        return(FALSE)
+    ans <- !SharedVector.compare(x@shared, x@offset + 1L,
+                                 y@shared, y@offset + 1L,
+                                 x@length)
+    as.logical(ans)
+}
+
+setMethod("==", signature(e1="XVector", e2="XVector"),
+    function(e1, e2) .XVector.equal(e1, e2)
+)
+

--- a/R/XVector-class.R
+++ b/R/XVector-class.R
@@ -169,6 +169,8 @@ setMethod("bindROWS", "XVector", .concatenate_XVector_objects)
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### Equality
 ###
+### order() and sameAsPreviousROW are required to make XVector compatible with
+### the equality functions defined in S4Vectors
 
 .XVector.equal <- function(x, y)
 {
@@ -184,3 +186,30 @@ setMethod("==", signature(e1="XVector", e2="XVector"),
     function(e1, e2) .XVector.equal(e1, e2)
 )
 
+.XVector.order <- function(x, decreasing=FALSE){
+    SharedVector.order(x@shared, decreasing)
+}
+setMethod("order", "XVector",
+    function(..., na.last=TRUE, decreasing=FALSE, method=c("auto", "shell", "radix")){
+        args <- list(...)
+        if (length(args) == 1L) {
+            x <- args[[1L]]
+            .XVector.order(x, decreasing)
+        } else {
+            args <- unname(args)
+            do.call(order, c(args, list(na.last=na.last,
+                                        decreasing=decreasing,
+                                        method=method)))
+        }
+    }
+)
+
+.XVector.sameAsPreviousROW <- function(x){
+    if(NROW(x) == 0){
+        logical(0L)
+    } else {
+        c(FALSE, vapply(seq_along(head(x,n=-1L)),
+                        \(i){ x[i] == x[i+1] }, logical(1L)))
+    }
+}
+setMethod("sameAsPreviousROW", "XVector", .XVector.sameAsPreviousROW)

--- a/man/XVector-class.Rd
+++ b/man/XVector-class.Rd
@@ -15,6 +15,13 @@
 \alias{as.numeric,XVector-method}
 \alias{show,XVector-method}
 \alias{==,XVector,XVector-method}
+\alias{<=,XVector,XVector-method}
+\alias{>=,XVector,XVector-method}
+\alias{<,XVector,XVector-method}
+\alias{>,XVector,XVector-method}
+\alias{!=,XVector,XVector-method}
+\alias{pcompare,XVector,XVector-method}
+\alias{order,XVector,XVector-method}
 
 % XRaw class, functions and methods:
 \alias{class:XRaw}
@@ -78,6 +85,31 @@
   The purpose of the X* containers is to provide a "pass by address"
   semantic and also to avoid the overhead of copying the sequence
   data when a linear subsequence needs to be extracted.
+}
+
+\section{Comparison operations on XVector objects}{
+Unlike the R's base vectors, comparing two XVector objects works \emph{atomically} -- that is, it doesn't compare element-by-element, but rather the two vectors as a whole. Thus, the return value of a comparison between two XVector objects will always be a single logical value. Comparison between an XVector and a base vector is performed by coercing the base vector to the same type as the XVector prior to comparison (potentially throwing an error if the comparison is impossible!).
+
+For element-wise comparison, the following are provided:
+
+  \describe{
+    \item{\code{pcompare(x,y)}:}{
+      Compares the elements of two vectors \code{x} and \code{y} in an
+      element-wise fashion. If \code{length(x) != length(y)}, the shorter
+      length vector is recycled to the length of the longer. Returns a
+      vector where the i'th element is:
+      \itemize{
+      \item negative if \code{x[i] < y[i]}
+      \item zero if \code{x[i] == y[i]}
+      \item positive if \code{x[i] > y[i]}
+      } More details are
+      available in the help page available via S4Vectors:
+      \code{\link[S4Vectors]{pcompare}}.
+    }
+    \item{\code{order(..., na.last=TRUE, decreasing=FALSE, method=c("auto", "shell", "radix"))}:}{
+      Returns a permutation vector that rearranges its first argument into ascending or descending order, similar to \code{\link[base]{order}}. Argument \code{na.last} is ignored, since XVector objects do not allow \code{NA} values. Argument \code{method} is currently ignored, but will be implemented in the future. If multiple XVectors are passed, returns a list of permutation vectors for each XVector.
+    }
+  }
 }
 
 \section{Additional Subsetting operations on XVector objects}{
@@ -168,6 +200,26 @@
 
   x3[length(x3):1]
   x3[length(x3):1, drop=FALSE]
+
+  ## ---------------------------------------------------------------------
+  ## C. Comparing XVector OBJECTS
+  ## ---------------------------------------------------------------------
+  xv <- XInteger(5, 1:5)
+  yv <- XInteger(5, 5:1)
+
+  ## Comparison between XVector objects is ATOMIC
+  xv == yv ## FALSE
+  xv <  yv ## TRUE
+
+  ## Element-wise comparison uses pcompare
+  pcompare(xv, yv)  ## -1 -1  0  1  1
+  pcompare(yv, xv)  ##  1  1  0 -1 -1
+  pcompare(xv, 5:1) ## equivalent to pcompare(xv, yv)
+
+  ## Convert to T/F values by comparing against zero:
+  pcompare(xv, yv) <  0 ## element-wise xv <  yv
+  pcomapre(xv, yv) >= 0 ## element-size xv >= yv
+
 }
 
 \keyword{methods}

--- a/src/R_init_XVector.c
+++ b/src/R_init_XVector.c
@@ -32,6 +32,7 @@ static const R_CallMethodDef callMethods[] = {
 	CALLMETHOD_DEF(SharedVector_Ocopy_from_start, 6),
 	CALLMETHOD_DEF(SharedVector_Ocopy_from_subscript, 4),
 	CALLMETHOD_DEF(SharedVector_mcopy, 7),
+	CALLMETHOD_DEF(SharedVector_order, 3),
 
 /* SharedRaw_class.c */
 	CALLMETHOD_DEF(SharedRaw_new, 2),

--- a/src/R_init_XVector.c
+++ b/src/R_init_XVector.c
@@ -29,10 +29,10 @@ static const R_CallMethodDef callMethods[] = {
 	CALLMETHOD_DEF(externalptr_show, 1),
 	CALLMETHOD_DEF(SharedVector_address0, 1),
 	CALLMETHOD_DEF(SharedVector_memcmp, 5),
+	CALLMETHOD_DEF(SharedVector_order, 3),
 	CALLMETHOD_DEF(SharedVector_Ocopy_from_start, 6),
 	CALLMETHOD_DEF(SharedVector_Ocopy_from_subscript, 4),
 	CALLMETHOD_DEF(SharedVector_mcopy, 7),
-	CALLMETHOD_DEF(SharedVector_order, 3),
 
 /* SharedRaw_class.c */
 	CALLMETHOD_DEF(SharedRaw_new, 2),

--- a/src/XVector.h
+++ b/src/XVector.h
@@ -311,6 +311,8 @@ SEXP SharedVector_memcmp(
 	SEXP width
 );
 
+SEXP SharedVector_order(SEXP x, SEXP width, SEXP descending);
+
 SEXP SharedVector_Ocopy_from_start(
 	SEXP out,
 	SEXP in,


### PR DESCRIPTION
This is part 2 of a PR, you can find part 1 here: https://github.com/Bioconductor/S4Vectors/pull/127

Background is covered in that PR description; this one will just cover was wasn't mentioned there.

This PR implements the XVector methods required to allow comparisons between XVectors. After merging both these PRs, the following are now supported:
```
x <- DNAString("ATGC")
x[order(x)]
## 4-letter DNAString object
## seq: ACGT

x == "A"
## [1] FALSE FALSE FALSE  TRUE

pcompare(x, DNAString("GCCC")) == 0
## [1]  TRUE  TRUE FALSE FALSE

x <- as(1:10, "XInteger")
x == 1:10
## [1] TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE

x <= 10:1
## [1]  TRUE  TRUE  TRUE  TRUE  TRUE FALSE FALSE FALSE FALSE FALSE

identical(10:1 < x, 10:1 < as.integer(x))
## [1] TRUE

```

And similarly for `XRaw` and `XDouble` objects.

## Known Issues:

1. Different sorting methods aren't supported for `SharedVector.order` or `XVector.order`. That implementation will depend on the backend being implemented in S4Vectors (see [this comment](https://github.com/ahl27/S4Vectors/blob/a6fe1b757d64f31c4a01df69d1e4b12cdd0f6dd7/src/sort_utils.c#L1406)).
2. No `sameAsPreviousROW` function exists for `SharedVector` objects, only `XVector`. Do we need one for `SharedVector`? Since the class isn't exported I'm not sure if it's necessary.