### PR TITLE
Attach RUnit before suite

### DIFF
--- a/tests/run_unitTests.R
+++ b/tests/run_unitTests.R
@@ -1,2 +1,3 @@
 require("XVector") || stop("unable to load XVector package")
+require("RUnit") || stop("unable to load RUnit package")
 XVector:::.test()


### PR DESCRIPTION
Ideally, we can remove `library(RUnit)` from {BiocGenerics}:

https://github.com/Bioconductor/BiocGenerics/blob/d3baf57ee632d96b02ee48ec30206164ac9c0152/R/testPackage.R#L75

Though it's a much bigger effort than just this change, I think it's independently a step in a good direction by making the dependencies of the test suite more evident